### PR TITLE
Update maxplayers launcharg

### DIFF
--- a/bullseye/etc/entry.sh
+++ b/bullseye/etc/entry.sh
@@ -32,7 +32,7 @@ cd "${STEAMAPPDIR}/game/bin/linuxsteamrt64"
 	-port "${CS2_PORT}" \
 	-console \
 	-usercon \
-	-maxplayers_override "${CS2_MAXPLAYERS}" \
+	-maxplayers "${CS2_MAXPLAYERS}" \
 	+game_type "${CS2_GAMETYPE}" \
 	+game_mode "${CS2_GAMEMODE}" \
 	+mapgroup "${CS2_MAPGROUP}" \


### PR DESCRIPTION
`CS2_MAXPLAYERS` env variable isn't being respected as Valve changed the launch arg from `-maxplayers_override` to `-maxplayers` 

see https://developer.valvesoftware.com/wiki/Maxplayers
> In  [Counter-Strike 2](https://developer.valvesoftware.com/wiki/Counter-Strike_2), maxplayers_override is deprecated. Use the [launch option](https://developer.valvesoftware.com/wiki/Command_Line_Options) -maxplayers <number> instead.