### PR TITLE
Change behaviour for hostname and add setsteamaccount

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ CS2_ADDITIONAL_ARGS=""      (Optional additional arguments to pass into cs2)
 CS2_BOT_DIFFICULTY=""       (0 - easy, 1 - normal, 2 - hard, 3 - expert)
 CS2_BOT_QUOTA=""            (Number of bots)
 CS2_BOT_QUOTA_MODE=""       (fill, competitive)
+CS2_STEAMTOKEN=""           (Use App-ID 730 at https://steamcommunity.com/dev/managegameservers)
 ```
 
 # Credits

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -38,7 +38,7 @@ ENV CS2_SERVERNAME="New \"${STEAMAPP}\" Server" \
     CS2_GAMETYPE=0 \
     CS2_GAMEMODE=1 \
     CS2_LAN=0 \
-	CS2_STEAMTOKEN="changeme" \
+    CS2_STEAMTOKEN="changeme" \
     CS2_ADDITIONAL_ARGS=""
 
 # Switch to user

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -38,6 +38,7 @@ ENV CS2_SERVERNAME="New \"${STEAMAPP}\" Server" \
     CS2_GAMETYPE=0 \
     CS2_GAMEMODE=1 \
     CS2_LAN=0 \
+	CS2_STEAMTOKEN="changeme" \
     CS2_ADDITIONAL_ARGS=""
 
 # Switch to user

--- a/bullseye/etc/entry.sh
+++ b/bullseye/etc/entry.sh
@@ -8,8 +8,7 @@ bash "${STEAMCMDDIR}/steamcmd.sh" +force_install_dir "${STEAMAPPDIR}" \
 				+app_update "${STEAMAPPID}" \
 				+quit
 
-sed -i -e "s/{{SERVER_HOSTNAME}}/${CS2_SERVERNAME}/g" \
-	-e "s/{{SERVER_PW}}/${CS2_PW}/g" \
+sed -i -e "s/{{SERVER_PW}}/${CS2_PW}/g" \
 	-e "s/{{SERVER_RCON_PW}}/${CS2_RCONPW}/g" \
 	-e "s/{{SERVER_LAN}}/${CS2_LAN}/g" "${STEAMAPPDIR}/game/csgo/cfg/server.cfg" \
 
@@ -39,4 +38,6 @@ cd "${STEAMAPPDIR}/game/bin/linuxsteamrt64"
 	+map "${CS2_STARTMAP}" \
 	+rcon_password "${CS2_RCONPW}" \
 	+sv_password "${CS2_PW}" \
+	+hostname "${CS2_SERVERNAME}" \
+	+sv_setsteamaccount "${CS2_STEAMTOKEN}" \
 	"${CS2_ADDITIONAL_ARGS}"

--- a/bullseye/etc/server.cfg
+++ b/bullseye/etc/server.cfg
@@ -1,6 +1,5 @@
 // Server Defaults
 
-hostname "{{SERVER_HOSTNAME}}"
 sv_lan {{SERVER_LAN}}
 
 // Passwords


### PR DESCRIPTION
Removed server hostname configuration from server.cfg and added it as a runtime parameter so the server name can be changed, allowing for multiple servers using the same server.cfg. Note that this will only work for new servers, as server.cfg takes precedence.

Also added +sv_setsteamaccount and CS2_STEAMTOKEN and updated README.md, so servers can be visible in the server browser.